### PR TITLE
Hide h5 and h6 elements

### DIFF
--- a/src/pagetoc.js
+++ b/src/pagetoc.js
@@ -42,7 +42,6 @@ window.addEventListener('load', function() {
     Array.prototype.forEach.call(elements, function(el) {
         var link = document.createElement("a");
 
-        // Indent shows hierarchy
         switch (el.parentElement.tagName) {
             case "H1":
                 break;

--- a/src/pagetoc.js
+++ b/src/pagetoc.js
@@ -37,23 +37,29 @@ window.addEventListener('load', function() {
         var link = document.createElement("a");
 
         // Indent shows hierarchy
-        var indent = "";
+        var indent = null;
         switch (el.parentElement.tagName) {
+            case "H1":
+                indent = 0;
             case "H2":
-                indent = "20px";
+                indent = 1;
                 break;
             case "H3":
-                indent = "40px";
+                indent = 2;
                 break;
             case "H4":
-                indent = "60px";
-                break;
-            default:
+                indent = 3;
                 break;
         }
 
         link.appendChild(document.createTextNode(el.text));
-        link.style.paddingLeft = indent;
+
+        if (indent) {
+           link.style.paddingLeft = `${indent * 20}px`;
+        } else {
+           link.style.display = "none";
+        }
+
         link.href = el.href;
         pagetoc.appendChild(link);
     });

--- a/src/pagetoc.js
+++ b/src/pagetoc.js
@@ -29,6 +29,12 @@ var updateFunction = function() {
     });
 };
 
+const indent = (element, level) => {
+    if (level) {
+        element.style.paddingLeft = `${level * 20}px`;
+    }
+}
+
 // Populate sidebar on load
 window.addEventListener('load', function() {
     var pagetoc = document.getElementsByClassName("pagetoc")[0];
@@ -37,27 +43,24 @@ window.addEventListener('load', function() {
         var link = document.createElement("a");
 
         // Indent shows hierarchy
-        var indent = null;
         switch (el.parentElement.tagName) {
+            case "H1":
+                break;
             case "H2":
-                indent = 0;
+                indent(link, 1);
                 break;
             case "H3":
-                indent = 1;
+                indent(link, 2);
                 break;
             case "H4":
-                indent = 2;
+                indent(link, 3);
+                break;
+            default:
+                link.style.display = "none";
                 break;
         }
 
         link.appendChild(document.createTextNode(el.text));
-
-        if (typeof indent === 'number') {
-           link.style.paddingLeft = `${(indent + 1) * 20}px`;
-        } else {
-           link.style.display = "none";
-        }
-
         link.href = el.href;
         pagetoc.appendChild(link);
     });

--- a/src/pagetoc.js
+++ b/src/pagetoc.js
@@ -39,23 +39,21 @@ window.addEventListener('load', function() {
         // Indent shows hierarchy
         var indent = null;
         switch (el.parentElement.tagName) {
-            case "H1":
-                indent = 0;
             case "H2":
-                indent = 1;
+                indent = 0;
                 break;
             case "H3":
-                indent = 2;
+                indent = 1;
                 break;
             case "H4":
-                indent = 3;
+                indent = 2;
                 break;
         }
 
         link.appendChild(document.createTextNode(el.text));
 
-        if (indent) {
-           link.style.paddingLeft = `${indent * 20}px`;
+        if (typeof indent === 'number') {
+           link.style.paddingLeft = `${(indent + 1) * 20}px`;
         } else {
            link.style.display = "none";
         }

--- a/src/pagetoc.js
+++ b/src/pagetoc.js
@@ -29,10 +29,13 @@ var updateFunction = function() {
     });
 };
 
-const indent = (element, level) => {
-    if (level) {
-        element.style.paddingLeft = `${level * 20}px`;
-    }
+const indentLevels = {
+    H1: 0,
+    H2: 1,
+    H3: 2,
+    H4: 3,
+    H5: 4,
+    H6: 5,
 }
 
 // Populate sidebar on load
@@ -40,23 +43,11 @@ window.addEventListener('load', function() {
     var pagetoc = document.getElementsByClassName("pagetoc")[0];
     var elements = document.getElementsByClassName("header");
     Array.prototype.forEach.call(elements, function(el) {
-        var link = document.createElement("a");
+        const link = document.createElement("a");
+        const indent = indentLevels[el.parentElement.tagName]
 
-        switch (el.parentElement.tagName) {
-            case "H1":
-                break;
-            case "H2":
-                indent(link, 1);
-                break;
-            case "H3":
-                indent(link, 2);
-                break;
-            case "H4":
-                indent(link, 3);
-                break;
-            default:
-                link.style.display = "none";
-                break;
+        if (indent) {
+            link.style.paddingLeft = `${indent * 20}px`;
         }
 
         link.appendChild(document.createTextNode(el.text));


### PR DESCRIPTION
Thanks for creating a useful plugin!

This PR hides `<h5 />` and `<h6 />` elements that are indented wrongly in the current implementation. In the future, we might want to make a sidebar's width and header levels configurable. But for now, I just hid them so that they don't get confused with `<h1 />` elements.

# Examples

- [Live demo](https://pen-lang.org/references/language/syntax.html#comparison)

Before:

![Screenshot 2022-06-27 19 21 24](https://user-images.githubusercontent.com/9584358/176078079-97949a79-0b9d-46e6-b7a4-a01d058c1aa9.png)

After:

![Screenshot 2022-06-27 19 23 10](https://user-images.githubusercontent.com/9584358/176078095-4fb3952e-f53a-4344-b53c-1755b1b13196.png)
